### PR TITLE
Update Post.php

### DIFF
--- a/class/Post.php
+++ b/class/Post.php
@@ -184,9 +184,14 @@ class Post extends \XoopsObject
             $key                         = (string)(time() + $counter++);
             $this->attachmentArray[$key] = [
                 'name_saved'  => $name_saved,
-                'nameDisplay' => empty($nameDisplay) ? $nameDisplay : $name_saved,
+                 // BigKev73 >  without this change the nameDisplay will always get set to the $name_Saved, so in the forum it will show the on-disk filename instead of the name of the orginal file
+                //'nameDisplay' => empty($nameDisplay) ? $nameDisplay : $name_saved,
+                'nameDisplay' => !empty($nameDisplay) ? $nameDisplay : $name_saved,
                 'mimetype'    => $mimetype,
-                'numDownload' => empty($numDownload) ? (int)$numDownload : 0,
+                // BigKev73 >  without this change the numDownload will always be set to 0
+                //'numDownload' => empty($numDownload) ? (int)$numDownload : 0,
+                'numDownload' => !empty($numDownload) ? (int)$numDownload : 0,
+                 
             ];
         }
         $attachmentSave = null;


### PR DESCRIPTION
There needs to be changes to the SetAttachment logic otherwise the value stored for any attached files will be incorrect and the $nameDisplay will never show, only the $name_saved. The logic is inversed and the "empty" should be a "!empty". Same goes with the  $numDownload field.