### PR TITLE
Update topicmanager.php

### DIFF
--- a/topicmanager.php
+++ b/topicmanager.php
@@ -253,7 +253,8 @@ if (Request::getString('submit', '', 'POST')) {
             $topicHandler->insert($topicObject, true);
             $topicObject->loadFilters('update');
 
-            $sql = sprintf('UPDATE "%s" SET forum_id = "%u" WHERE topic_id = "%u"', $GLOBALS['xoopsDB']->prefix('newbb_posts'), $newforum, $topic_id);
+            //$sql = sprintf('UPDATE "%s" SET forum_id = "%u" WHERE topic_id = "%u"', $GLOBALS['xoopsDB']->prefix('newbb_posts'), $newforum, $topic_id);
+             $sql = sprintf("UPDATE %s SET forum_id = %u WHERE topic_id = %u", $GLOBALS['xoopsDB']->prefix('newbb_posts'), $newforum, $topic_id);
             if (!$r = $GLOBALS['xoopsDB']->query($sql)) {
                 return false;
             }


### PR DESCRIPTION
When moving a Topic from one forum to another, I was getting a blank screen. Also it left the topic in a weird state when it was partially moved. Showing in the correct forum, but last post and blocks showed it in the original forum.  I think this is because the the topic was updated, but the posts in that topic were not. Turned on debugging and at first saw this error:

Notice: XoopsObject::loadFilters() is deprecated, called from /modules/newbb/topicmanager.php line 251 in file /kernel/object.php line 949
Notice: XoopsObject::loadFilters() is deprecated, called from /modules/newbb/topicmanager.php line 254 in file /kernel/object.php line 949

So those loadFilters calls should be removed or addressed. But, even commenting those out didn't resolve the issue. So upon looking at the SQL calls, I see the following additional error:

0.000091 - UPDATE "newbb_posts" SET forum_id = "1" WHERE topic_id = "23793"
Error number: 1064
Error message: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '"xoo__newbb_posts" SET forum_id = "1" WHERE topic_id = "23793"' at line 1

So I modified to line 256 in topicmanager.php from:

$sql = sprintf('UPDATE "%s" SET forum_id = "%u" WHERE topic_id = "%u"', $GLOBALS['xoopsDB']->prefix('newbb_posts'), $newforum, $topic_id);

TO: 

 $sql = sprintf("UPDATE %s SET forum_id = %u WHERE topic_id = %u", $GLOBALS['xoopsDB']->prefix('newbb_posts'), $newforum, $topic_id);
            if (!$r = $GLOBALS['xoopsDB']->query($sql)) {

Which resolves the issue and properly moves the topic.