### PR TITLE
Update functions.image.php

### DIFF
--- a/include/functions.image.php
+++ b/include/functions.image.php
@@ -144,7 +144,7 @@ if (!defined('NEWBB_FUNCTIONS_IMAGE')) {
                 $new_file_im = @escapeshellarg($new_file);
             }
             $path           = empty($GLOBALS['xoopsModuleConfig']['path_magick']) ? '' : $GLOBALS['xoopsModuleConfig']['path_magick'] . '/';
-            $magick_command = $path . 'convert -quality 85 -antialias -sample ' . $newWidth . 'x' . $newHeight . ' ' . $src_file_im . ' +profile "*" ' . str_replace('\\', '/', $new_file_im) . '';
+            $magick_command = $path . 'convert -auto-orient -quality 85 -antialias -sample ' . $newWidth . 'x' . $newHeight . ' ' . $src_file_im . ' +profile "*" ' . str_replace('\\', '/', $new_file_im) . '';
 
             @passthru($magick_command);
             if (file_exists($new_file)) {


### PR DESCRIPTION
Add  -auto-orient switch to image magick thumbnail command otherwise, thumbnails could get created with the incorrect orientation if the EXIF tag in the file is specifying a different one. This happens with images taken with mobile devices. The browser automatically read the EXIF tag and views the original image correctly, but without this switch, the generated thumbnails would could show up incorrectly.