### PR TITLE
Update search.php

### DIFF
--- a/search.php
+++ b/search.php
@@ -77,7 +77,7 @@ if (!empty($uname) || Request::getString('submit', '') || !empty($term)) {
     $next_search['selectlength'] = $selectlength;
 
     $start = Request::getInt('start', 0);
-    $forum = Request::getInt('forum', null);
+    $forum = Request::getVar('forum', null);
     if (empty($forum) || 'all' === $forum || (is_array($forum) && in_array('all', $forum, true))) {
         $forum = [];
     } elseif (!is_array($forum)) {


### PR DESCRIPTION
Change from getInt to getVar. The getInt causes the forum array value to become null as its a type mismatch, which means the search with a forum filter never works. So, it defaults to all forums.